### PR TITLE
Fix to inverse of negative MC object

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "McCormick"
 uuid = "53c679d3-6890-5091-8386-c291e8c8aaa1"
 authors = ["Matthew Wilhelm <matthew.wilhelm@uconn.edu>"]
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"

--- a/src/forward_operators/power.jl
+++ b/src/forward_operators/power.jl
@@ -260,7 +260,7 @@ end
 	return MC{N,Diff}(cv, cc, y, cv_grad, cc_grad, x.cnst)
 end
 
-# neg_powneg_odd computes the McComrick relaxation of x^c where x < 0.0 and c is even
+# neg_powneg_even computes the McComrick relaxation of x^c where x < 0.0 and c is even
 @inline function neg_powneg_even(x::MC{N,T}, c::Z, y::Interval{Float64}) where {N, Z<:Integer, T<:Union{NS,MV}}
 	xL = x.Intv.lo
 	xU = x.Intv.hi
@@ -429,7 +429,7 @@ end
 		return nan(MC{N,T})
 	end
 	if x.Intv.hi < 0.0
-		x = pos_odd(x, -1, y)
+		x = -inv1(-x, -y)
   	else x.Intv.lo > 0.0
 		x = inv1(x, y)
 	end

--- a/test/forward_mccormick.jl
+++ b/test/forward_mccormick.jl
@@ -1295,6 +1295,18 @@ end
     @test isapprox(out.Intv.lo,-1.33333333,atol=1E-6)
     @test isapprox(out.Intv.hi,-0.39999999999999997,atol=1E-6)
 
+    X = MC{2,NS}(3.0,3.0,Interval{Float64}(2.0,4.0), seed_gradient(1,Val(2)),seed_gradient(1,Val(2)),false)
+    Y = MC{2,NS}(-5.0,-3.0,Interval{Float64}(-5.0,-3.0), seed_gradient(2,Val(2)), seed_gradient(2,Val(2)),false)
+    out = X/Y
+    @test isapprox(out.cc, -0.6000000000000001,atol=1E-6)
+    @test isapprox(out.cv, -0.9999999999999998, atol=1E-6)
+    @test isapprox(out.cc_grad[1], -0.19999999999999998, atol=1E-6)
+    @test isapprox(out.cc_grad[2], -0.08,atol=1E-6)
+    @test isapprox(out.cv_grad[1], -0.33333333333333337, atol=1E-6)
+    @test isapprox(out.cv_grad[2], -0.13333333333333333, atol=1E-6)
+    @test isapprox(out.Intv.lo, -1.3333333333333335,atol=1E-6)
+    @test isapprox(out.Intv.hi, -0.39999999999999997,atol=1E-6)
+
     x1a = MC{2,MV}(1.1, 2.3, Interval(0.1,3.3), seed_gradient(2,Val(2)), seed_gradient(2,Val(2)),false)
     x2a = MC{2,MV}(2.1, 3.3, Interval(1.1,4.3), seed_gradient(2,Val(2)), seed_gradient(2,Val(2)),false)
 


### PR DESCRIPTION
-Inverse of a negative-domain MC object now returns the negative inverse of the negated input. 
-Add a test for inversion where the domain is negative and the cv/cc relaxations are not identical.